### PR TITLE
Fix(parser): the quantifier after unnecessary escaped chars

### DIFF
--- a/src/parser/__tests__/valid-2015.test.ts
+++ b/src/parser/__tests__/valid-2015.test.ts
@@ -4327,6 +4327,26 @@ const tests: Tests = {
     literal: true,
     escapeBackslash: false,
   },
+  '/\\aaa?/': {
+    id: '',
+    type: 'regex',
+    body: [{
+      id: '',
+      type: 'character',
+      kind: 'string',
+      value: 'aa',
+      quantifier: null,
+    }, {
+      id: '',
+      type: 'character',
+      kind: 'string',
+      value: 'a',
+      quantifier: { kind: '?', min: 0, max: 1, greedy: true },
+    }],
+    flags: [],
+    literal: true,
+    escapeBackslash: false,
+  },
 }
 
 const withoutGenRegex = [
@@ -4397,6 +4417,7 @@ const withoutGenRegex = [
   '/[\\c_]/',
   '/^[a-zA-Z0-9!-/:-@\\[-`{-~]*$/',
   '/^[ｧ-ﾝﾞﾟ\\-]*$/',
+  '/\\aaa?/',
 ]
 
 it('parse es2015 regex', () => {

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -72,7 +72,6 @@ export class Parser {
         ) {
           lastNode.value += str
           str = ''
-          return
         }
       }
       if (str) {


### PR DESCRIPTION
Close https://github.com/Bowen7/regex-vis/issues/137

To reproduce: input the regex `\aaa?`

This code will return early when there is a quantifier after unnecessary escaped chars. Just remove the `return`:

https://github.com/Bowen7/regex-vis/blob/d60999ed55d844870a0b95c15c3ace16d3bc7dbc/src/parser/parser.ts#L68-L96