### PR TITLE
Enhance Visual Differentiation for Similar Regex Components

### DIFF
--- a/src/modules/graph/group-like.tsx
+++ b/src/modules/graph/group-like.tsx
@@ -44,7 +44,7 @@ function GroupLikeNode({ x, y, node, selected }: Props) {
         height={contentSize[1]}
         rx={GRAPH_NODE_BORDER_RADIUS}
         ry={GRAPH_NODE_BORDER_RADIUS}
-        className="stroke-[1.5] stroke-graph-group fill-transparent "
+        className={`stroke-[1.5] fill-transparent ${('negate' in node && node.negate ? 'stroke-red-500 [stroke-dasharray:4_2]' : 'stroke-graph-group')}`}
       >
         {nodeChildren.length > 0 && (
           <>

--- a/src/modules/graph/simple-node.tsx
+++ b/src/modules/graph/simple-node.tsx
@@ -43,7 +43,7 @@ function SimpleNode({ x, y, node, selected }: Props) {
         rx={GRAPH_NODE_BORDER_RADIUS}
         ry={GRAPH_NODE_BORDER_RADIUS}
         fill="transparent"
-        className="stroke-[1.5] stroke-graph"
+        className={`stroke-[1.5] ${('negate' in node && node.negate ? 'stroke-red-500 [stroke-dasharray:4_2]' : 'stroke-graph')}`}
       >
         <foreignObject
           x={contentX + GRAPH_NODE_PADDING_HORIZONTAL}


### PR DESCRIPTION
Currently, the app uses the same line style and color for pairs of elements such as "one of" vs. "none of", "Preceded by:" vs. "Not preceded by:", and "Followed by:" vs. "Not followed by:". This similarity can make it hard to quickly distinguish between components that have different logical meanings.

Therefore, I wanted to change these line styles and colors. The goal of this PR is to enhance the clarity and visual communication of regex components. By differentiating these elements visually, users can more easily parse and understand complex regular expressions.

However, I fully understand and respect that the current design may have been chosen for specific reasons. My intention is simply to propose a possible enhancement, not to override any existing design decisions.